### PR TITLE
Bugfix: Plugin controls do not appear on Edit Entry page in MT Pro (MT4 and MT5)

### DIFF
--- a/plugins/HotDate/lib/HotDate/Plugin.pm
+++ b/plugins/HotDate/lib/HotDate/Plugin.pm
@@ -104,14 +104,14 @@ sub update_template {
     my $oldtext;
     # MT5
     if (
-        $app->product_name eq 'Movable Type'
+        $app->product_name =~ /^Movable Type/
         && $app->product_version > 5
     ) {
         $oldtext = q{<span class="separator"> <__trans phrase="@"></span> <input type="text" class="text time <mt:if name="status_future"><mt:if name="can_publish_post"> highlight</mt:if></mt:if>" name="authored_on_time" value="<$mt:var name="authored_on_time" escape="html"$>" />};
     }
     # MT 4.25 and older
     elsif (
-        $app->product_name eq 'Movable Type'
+        $app->product_name =~ /^Movable Type/
         && $app->product_version < 4.25
     ) {
         $oldtext = q{<input class="entry-time" name="authored_on_time" tabindex="11" value="<$mt:var name="authored_on_time" escape="html"$>" />};


### PR DESCRIPTION
Changed check of product name to regex because MT->product_name can have one of at least 6 possible values in MT4-MT5:
- Movable Type
- Movable Type Open Source
- Movable Type Publishing Platform
- Movable Type Pro
- Movable Type Enterprise
- Movable Type Advanced
