### PR TITLE
Minor HTML fix for now.png link

### DIFF
--- a/plugins/HotDate/lib/HotDate/Plugin.pm
+++ b/plugins/HotDate/lib/HotDate/Plugin.pm
@@ -124,14 +124,13 @@ sub update_template {
 
     # Build the new fields. Lots of HTML!
     my $newtext = <<'END_HTML';
-    <a href="javascript:hd_current();" style="margin-left: 18px;">
-        <img src="<mt:StaticWebPath>support/plugins/hotdate/now.png"
+    <a href="javascript:hd_current();" style="margin-left: 18px;"><img
+        src="<mt:StaticWebPath>support/plugins/hotdate/now.png"
             width="16"
             height="16"
             border="0"
             alt="Update to current date/time"
-            title="Update to current date/time" />
-    </a>
+            title="Update to current date/time" /></a>
 
     <br style="clear: both;" />
 


### PR DESCRIPTION
Minor fix to the HTML for the image link to prevent a spurious "_" from appearing after the image on certain browsers (in my case, Chrome) because of the way linebreaks are converted to spaces
