### PR TITLE
Fix current hour eq 12

### DIFF
--- a/plugins/HotDate/config.yaml
+++ b/plugins/HotDate/config.yaml
@@ -7,7 +7,7 @@ plugin_link:    http://eatdrinksleepmovabletype.com/plugins/hot_date/
 doc_link:       http://eatdrinksleepmovabletype.com/plugins/hot_date/documentation.php
 author_name:    'Dan Wolfgang, uiNNOVATIONS'
 author_link:    http://uinnovations.com/
-version:        2.1.1
+version:        2.1.2
 static_version: 1
 
 config_template:

--- a/plugins/HotDate/lib/HotDate/Plugin.pm
+++ b/plugins/HotDate/lib/HotDate/Plugin.pm
@@ -392,10 +392,12 @@ sub update_template {
         var hd_current_hour = hd_now.getHours();
         if (hd_current_hour >= 12) {
            hd_current_hour -= 12;
+           if (hd_current_hour == 0) { hd_current_hour = '12'; } // for 12 pm
            document.forms['entry_form'].hd_time_hours.value = hd_current_hour;
            document.forms['entry_form'].hd_time_ampm.value = 'pm';
         }
         else {
+           if (hd_current_hour == 0) { hd_current_hour = '12'; } // for 12 am
            document.forms['entry_form'].hd_time_hours.value = hd_current_hour;
            document.forms['entry_form'].hd_time_ampm.value = 'am';
         }


### PR DESCRIPTION
When the current time is in the 12am or 12pm range and the "Update to current date/time" button is clicked, the 'hours' drop-down box does not update.

This issue occurs because when the current hour is calculated, 12pm and 12am both evaluate to 0, which the hours dropdown has no value for.

The proposed fix sets the hour dropdown value to '12' when the current hour evaluates to 0 for both 12am and 12pm, which the hours dropdown box does have a value for.
